### PR TITLE
Handle trailing slash in provider `base_url`

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/Khan/genqlient/graphql"
@@ -21,6 +22,7 @@ func New(organization, token, baseURL string) *Client {
 	if baseURL == "" {
 		baseURL = fmt.Sprintf("https://%s.dagster.cloud", organization)
 	}
+	baseURL = strings.TrimRight(baseURL, "/")
 	return &Client{
 		Organization: organization,
 		BaseURL:      baseURL,

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -111,3 +111,20 @@ func TestClient_GraphQLError(t *testing.T) {
 		t.Errorf("error should include GQL message, got: %v", err)
 	}
 }
+
+func TestClient_TrailingSlashBaseURL(t *testing.T) {
+	var path string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		gqlOK(w, map[string]any{"deployments": []any{}})
+	}))
+	defer srv.Close()
+
+	c := client.New("test-org", "test-token", srv.URL+"/")
+	if _, err := c.ListDeployments(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != "/graphql" {
+		t.Errorf("path = %q, want /graphql", path)
+	}
+}


### PR DESCRIPTION
Handle trailing backslash in `base_url`

https://github.com/dagster-io/terraform-provider-dagsterplus/issues/14