### PR TITLE
Handle HTTP 500 PythonError

### DIFF
--- a/internal/client/agent_tokens.go
+++ b/internal/client/agent_tokens.go
@@ -32,6 +32,10 @@ func (c *Client) CreateAgentToken(ctx context.Context, name string) (*AgentToken
 			Name:  name,
 			Token: r.AgentTokenFields.Token,
 		}, nil
+	case *schema.CreateAgentTokenCreateAgentTokenPythonError:
+		return nil, fmt.Errorf("CreateAgentToken: Dagster Cloud returned an internal error; check your organization configuration or contact Dagster support")
+	case *schema.CreateAgentTokenCreateAgentTokenUnauthorizedError:
+		return nil, fmt.Errorf("CreateAgentToken: unauthorized; verify your API token has permission to create agent tokens")
 	default:
 		return nil, fmt.Errorf("CreateAgentToken: unexpected result type %T", resp.CreateAgentToken)
 	}
@@ -57,6 +61,10 @@ func (c *Client) ListAgentTokens(ctx context.Context) ([]AgentToken, error) {
 			})
 		}
 		return tokens, nil
+	case *schema.ListAgentTokensAgentTokensOrErrorPythonError:
+		return nil, fmt.Errorf("ListAgentTokens: Dagster Cloud returned an internal error; check your organization configuration or contact Dagster support")
+	case *schema.ListAgentTokensAgentTokensOrErrorUnauthorizedError:
+		return nil, fmt.Errorf("ListAgentTokens: unauthorized; verify your API token has permission to list agent tokens")
 	default:
 		return nil, fmt.Errorf("ListAgentTokens: unexpected result type %T", resp.AgentTokensOrError)
 	}

--- a/internal/client/agent_tokens_test.go
+++ b/internal/client/agent_tokens_test.go
@@ -2,6 +2,7 @@ package client_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -66,6 +67,36 @@ func TestCreateAgentToken_UnexpectedTypename(t *testing.T) {
 	_, err := newClient(srv).CreateAgentToken(context.Background(), "my-token")
 	if err == nil {
 		t.Fatal("expected error for empty token, got nil")
+	}
+}
+
+// TestCreateAgentToken_PythonError verifies that a PythonError response produces
+// a clear error, whether the server returns it with HTTP 200 or HTTP 500.
+// Some Dagster Cloud API versions return 500 for PythonError mutation results.
+func TestCreateAgentToken_PythonError(t *testing.T) {
+	pythonErrorBody := map[string]any{
+		"createAgentToken": map[string]any{
+			"__typename": "PythonError",
+		},
+	}
+	for _, statusCode := range []int{http.StatusOK, http.StatusInternalServerError} {
+		statusCode := statusCode
+		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(statusCode)
+				_ = json.NewEncoder(w).Encode(map[string]any{"data": pythonErrorBody})
+			}))
+			defer srv.Close()
+
+			_, err := newClient(srv).CreateAgentToken(context.Background(), "my-token")
+			if err == nil {
+				t.Fatalf("expected error for PythonError (status %d), got nil", statusCode)
+			}
+			if strings.Contains(err.Error(), "unexpected result type") {
+				t.Errorf("PythonError should be handled explicitly, got: %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,7 +1,10 @@
 package client
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -41,7 +44,29 @@ type tokenDoer struct {
 
 func (t *tokenDoer) Do(req *http.Request) (*http.Response, error) {
 	req.Header.Set("Dagster-Cloud-Api-Token", t.token)
-	return t.inner.Do(req)
+	resp, err := t.inner.Do(req)
+	if err != nil || resp.StatusCode != http.StatusInternalServerError {
+		return resp, err
+	}
+	// Some Dagster Cloud API versions return HTTP 500 when a GraphQL mutation
+	// resolves to a PythonError union member. Rewrite those responses to 200 so
+	// genqlient can parse and surface the error type through the normal union
+	// switch, rather than returning a raw HTTP error.
+	body, readErr := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if readErr != nil {
+		resp.Body = http.NoBody
+		return resp, nil
+	}
+	var check struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if json.Unmarshal(body, &check) == nil && len(check.Data) > 0 {
+		resp.StatusCode = http.StatusOK
+		resp.Status = "200 OK"
+	}
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	return resp, nil
 }
 
 // gqlClient returns a genqlient GraphQL client for the given deployment.


### PR DESCRIPTION
When the Dagster Cloud API returns HTTP 500 with a `PythonError` result in the response body, genqlient treats the response as a raw HTTP error and never routes it through the GraphQL union switch. This means the provider surfaces a cryptic "returned error 500: ..." message instead of anything actionable.

This PR fixes handling in two layers:
- tokenDoer.Do: intercepts HTTP 500 responses that carry a valid GraphQL `data` body and rewrites the status to 200, so genqlient parses
the response normally through the typed union switch rather than bailing out as an HTTP error.
- `CreateAgentToken` / `ListAgentTokens`: adds explicit `PythonError` and `UnauthorizedError` cases to both switch statements, replacing the generic "unexpected result type" fallback with clear, actionable error messages.

https://github.com/dagster-io/terraform-provider-dagsterplus/issues/15