### PR TITLE
Handle deployment id

### DIFF
--- a/docs/data-sources/deployment.md
+++ b/docs/data-sources/deployment.md
@@ -17,8 +17,8 @@ data "dagsterplus_deployment" "prod" {
   name = "prod"
 }
 
-output "prod_deployment_type" {
-  value = data.dagsterplus_deployment.prod.type
+output "prod_deployment_id" {
+  value = data.dagsterplus_deployment.prod.deployment_id
 }
 ```
 
@@ -31,6 +31,7 @@ output "prod_deployment_type" {
 
 ### Read-Only
 
+- `deployment_id` (String) The numeric deployment ID as a decimal string.
 - `id` (String) Deployment identifier (same as name).
 - `status` (String) The current status of the deployment (e.g. `ACTIVE`, `PENDING_DELETION`).
 - `type` (String) The deployment type: `SERVERLESS`, `HYBRID`, or `BRANCH`.

--- a/docs/data-sources/deployments.md
+++ b/docs/data-sources/deployments.md
@@ -33,6 +33,7 @@ output "deployment_names" {
 
 Read-Only:
 
+- `deployment_id` (String) The numeric deployment ID as a decimal string.
 - `id` (String) Deployment identifier (same as name).
 - `name` (String) The deployment name.
 - `status` (String) The deployment status.

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -15,16 +15,10 @@ Manages a Dagster+ deployment.
 ```terraform
 resource "dagsterplus_deployment" "prod" {
   name = "prod"
-  type = "SERVERLESS"
-}
-
-resource "dagsterplus_deployment" "hybrid" {
-  name = "hybrid-prod"
-  type = "HYBRID"
 }
 
 output "prod_deployment_id" {
-  value = dagsterplus_deployment.prod.id
+  value = dagsterplus_deployment.prod.deployment_id
 }
 ```
 
@@ -37,6 +31,7 @@ output "prod_deployment_id" {
 
 ### Read-Only
 
+- `deployment_id` (String) The numeric deployment ID as a decimal string. Use this with GraphQL mutations such as `createOrUpdateAgentPermissions`.
 - `id` (String) Deployment identifier (same as name).
 - `status` (String) The current status of the deployment (e.g. ACTIVE, PENDING_DELETION).
 

--- a/examples/data-sources/dagsterplus_deployment/data-source.tf
+++ b/examples/data-sources/dagsterplus_deployment/data-source.tf
@@ -2,6 +2,6 @@ data "dagsterplus_deployment" "prod" {
   name = "prod"
 }
 
-output "prod_deployment_type" {
-  value = data.dagsterplus_deployment.prod.type
+output "prod_deployment_id" {
+  value = data.dagsterplus_deployment.prod.deployment_id
 }

--- a/examples/resources/dagsterplus_deployment/resource.tf
+++ b/examples/resources/dagsterplus_deployment/resource.tf
@@ -1,13 +1,7 @@
 resource "dagsterplus_deployment" "prod" {
   name = "prod"
-  type = "SERVERLESS"
-}
-
-resource "dagsterplus_deployment" "hybrid" {
-  name = "hybrid-prod"
-  type = "HYBRID"
 }
 
 output "prod_deployment_id" {
-  value = dagsterplus_deployment.prod.id
+  value = dagsterplus_deployment.prod.deployment_id
 }

--- a/internal/client/deployments_test.go
+++ b/internal/client/deployments_test.go
@@ -10,6 +10,7 @@ import (
 
 func mockDeployment() map[string]any {
 	return map[string]any{
+		"deploymentId":   42,
 		"deploymentName": "prod",
 		"deploymentType": "PROD",
 	}
@@ -30,6 +31,7 @@ func TestCreateDeployment_Success(t *testing.T) {
 		gqlOK(w, map[string]any{
 			"createDeployment": map[string]any{
 				"__typename":     "DagsterCloudDeployment",
+				"deploymentId":   99,
 				"deploymentName": "prod",
 				"deploymentType": "PROD",
 			},
@@ -46,6 +48,9 @@ func TestCreateDeployment_Success(t *testing.T) {
 	}
 	if dep.Type != "PROD" {
 		t.Errorf("Type = %q, want PROD", dep.Type)
+	}
+	if dep.IntID != 99 {
+		t.Errorf("IntID = %d, want 99", dep.IntID)
 	}
 }
 
@@ -99,6 +104,9 @@ func TestListDeployments_Success(t *testing.T) {
 	}
 	if deps[0].Name != "prod" {
 		t.Errorf("Name = %q, want prod", deps[0].Name)
+	}
+	if deps[0].IntID != 42 {
+		t.Errorf("IntID = %d, want 42", deps[0].IntID)
 	}
 }
 

--- a/internal/datasources/data_source_deployment.go
+++ b/internal/datasources/data_source_deployment.go
@@ -3,6 +3,7 @@ package datasources
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/dagster-io/terraform-provider-dagsterplus/internal/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -25,10 +26,11 @@ type deploymentDataSource struct {
 
 // deploymentDataSourceModel describes the data source data model.
 type deploymentDataSourceModel struct {
-	ID     types.String `tfsdk:"id"`
-	Name   types.String `tfsdk:"name"`
-	Type   types.String `tfsdk:"type"`
-	Status types.String `tfsdk:"status"`
+	ID           types.String `tfsdk:"id"`
+	Name         types.String `tfsdk:"name"`
+	Type         types.String `tfsdk:"type"`
+	Status       types.String `tfsdk:"status"`
+	DeploymentID types.String `tfsdk:"deployment_id"`
 }
 
 func (d *deploymentDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -53,6 +55,10 @@ func (d *deploymentDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 			},
 			"status": schema.StringAttribute{
 				Description: "The current status of the deployment (e.g. `ACTIVE`, `PENDING_DELETION`).",
+				Computed:    true,
+			},
+			"deployment_id": schema.StringAttribute{
+				Description: "The numeric deployment ID as a decimal string.",
 				Computed:    true,
 			},
 		},
@@ -89,10 +95,11 @@ func (d *deploymentDataSource) Read(ctx context.Context, req datasource.ReadRequ
 	}
 
 	state := deploymentDataSourceModel{
-		ID:     types.StringValue(deployment.Name),
-		Name:   types.StringValue(deployment.Name),
-		Type:   types.StringValue(deployment.Type),
-		Status: types.StringValue(deployment.Status),
+		ID:           types.StringValue(deployment.Name),
+		Name:         types.StringValue(deployment.Name),
+		Type:         types.StringValue(deployment.Type),
+		Status:       types.StringValue(deployment.Status),
+		DeploymentID: types.StringValue(strconv.FormatInt(deployment.IntID, 10)),
 	}
 
 	diags = resp.State.Set(ctx, state)

--- a/internal/datasources/data_source_deployment_test.go
+++ b/internal/datasources/data_source_deployment_test.go
@@ -60,4 +60,20 @@ func TestDeploymentDataSource_Schema(t *testing.T) {
 	if idAttr.IsRequired() {
 		t.Error("id should not be Required")
 	}
+
+	// "deployment_id" must be Computed only
+	deplIDRaw, ok := resp.Schema.Attributes["deployment_id"]
+	if !ok {
+		t.Fatal("missing 'deployment_id' attribute")
+	}
+	deplIDAttr, ok := deplIDRaw.(dsschema.StringAttribute)
+	if !ok {
+		t.Fatalf("deployment_id should be StringAttribute, got %T", deplIDRaw)
+	}
+	if !deplIDAttr.IsComputed() {
+		t.Error("deployment_id should be Computed")
+	}
+	if deplIDAttr.IsRequired() {
+		t.Error("deployment_id should not be Required")
+	}
 }

--- a/internal/datasources/data_source_deployments.go
+++ b/internal/datasources/data_source_deployments.go
@@ -3,6 +3,7 @@ package datasources
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/dagster-io/terraform-provider-dagsterplus/internal/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -58,6 +59,10 @@ func (d *deploymentsDataSource) Schema(_ context.Context, _ datasource.SchemaReq
 							Description: "The deployment status.",
 							Computed:    true,
 						},
+						"deployment_id": schema.StringAttribute{
+							Description: "The numeric deployment ID as a decimal string.",
+							Computed:    true,
+						},
 					},
 				},
 			},
@@ -93,9 +98,11 @@ func (d *deploymentsDataSource) Read(ctx context.Context, _ datasource.ReadReque
 	}
 	for i, dep := range deployments {
 		state.Deployments[i] = deploymentDataSourceModel{
-			ID:   types.StringValue(dep.Name),
-			Name: types.StringValue(dep.Name),
-			Type: types.StringValue(dep.Type),
+			ID:           types.StringValue(dep.Name),
+			Name:         types.StringValue(dep.Name),
+			Type:         types.StringValue(dep.Type),
+			Status:       types.StringValue(dep.Status),
+			DeploymentID: types.StringValue(strconv.FormatInt(dep.IntID, 10)),
 		}
 	}
 

--- a/internal/provider/acceptance_data_source_deployment_test.go
+++ b/internal/provider/acceptance_data_source_deployment_test.go
@@ -18,6 +18,7 @@ func TestAccDeploymentDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.dagsterplus_deployment.test", "name", "acc-tf-ds-dep"),
 					resource.TestCheckResourceAttrSet("data.dagsterplus_deployment.test", "id"),
 					resource.TestCheckResourceAttrSet("data.dagsterplus_deployment.test", "status"),
+					resource.TestCheckResourceAttrSet("data.dagsterplus_deployment.test", "deployment_id"),
 				),
 			},
 		},

--- a/internal/provider/acceptance_resource_deployment_test.go
+++ b/internal/provider/acceptance_resource_deployment_test.go
@@ -27,6 +27,7 @@ func TestAccDeploymentResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("dagsterplus_deployment.test", "name", rName),
 					resource.TestCheckResourceAttrSet("dagsterplus_deployment.test", "id"),
 					resource.TestCheckResourceAttrSet("dagsterplus_deployment.test", "status"),
+					resource.TestCheckResourceAttrSet("dagsterplus_deployment.test", "deployment_id"),
 				),
 			},
 			// Import

--- a/internal/resources/resource_deployment.go
+++ b/internal/resources/resource_deployment.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/dagster-io/terraform-provider-dagsterplus/internal/client"
@@ -29,9 +30,10 @@ type deploymentResource struct {
 
 // deploymentResourceModel describes the resource data model.
 type deploymentResourceModel struct {
-	ID     types.String `tfsdk:"id"`
-	Name   types.String `tfsdk:"name"`
-	Status types.String `tfsdk:"status"`
+	ID           types.String `tfsdk:"id"`
+	Name         types.String `tfsdk:"name"`
+	Status       types.String `tfsdk:"status"`
+	DeploymentID types.String `tfsdk:"deployment_id"`
 }
 
 func (r *deploymentResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -58,6 +60,13 @@ func (r *deploymentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 			},
 			"status": schema.StringAttribute{
 				Description: "The current status of the deployment (e.g. ACTIVE, PENDING_DELETION).",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"deployment_id": schema.StringAttribute{
+				Description: "The numeric deployment ID as a decimal string. Use this with GraphQL mutations such as `createOrUpdateAgentPermissions`.",
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -98,6 +107,7 @@ func (r *deploymentResource) Create(ctx context.Context, req resource.CreateRequ
 	plan.ID = types.StringValue(deployment.Name)
 	plan.Name = types.StringValue(deployment.Name)
 	plan.Status = types.StringValue(deployment.Status)
+	plan.DeploymentID = types.StringValue(strconv.FormatInt(deployment.IntID, 10))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
@@ -122,6 +132,7 @@ func (r *deploymentResource) Read(ctx context.Context, req resource.ReadRequest,
 	state.ID = types.StringValue(deployment.Name)
 	state.Name = types.StringValue(deployment.Name)
 	state.Status = types.StringValue(deployment.Status)
+	state.DeploymentID = types.StringValue(strconv.FormatInt(deployment.IntID, 10))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
@@ -153,9 +164,10 @@ func (r *deploymentResource) ImportState(ctx context.Context, req resource.Impor
 	}
 
 	state := deploymentResourceModel{
-		ID:     types.StringValue(deployment.Name),
-		Name:   types.StringValue(deployment.Name),
-		Status: types.StringValue(deployment.Status),
+		ID:           types.StringValue(deployment.Name),
+		Name:         types.StringValue(deployment.Name),
+		Status:       types.StringValue(deployment.Status),
+		DeploymentID: types.StringValue(strconv.FormatInt(deployment.IntID, 10)),
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)

--- a/internal/resources/resource_deployment_test.go
+++ b/internal/resources/resource_deployment_test.go
@@ -44,4 +44,20 @@ func TestDeploymentResource_Schema(t *testing.T) {
 	if nameAttr.IsComputed() {
 		t.Error("name should not be Computed")
 	}
+
+	// deployment_id: Computed only, UseStateForUnknown
+	deplIDRaw, ok := resp.Schema.Attributes["deployment_id"]
+	if !ok {
+		t.Fatal("missing 'deployment_id' attribute")
+	}
+	deplIDAttr, ok := deplIDRaw.(rsschema.StringAttribute)
+	if !ok {
+		t.Fatalf("deployment_id should be StringAttribute, got %T", deplIDRaw)
+	}
+	if !deplIDAttr.IsComputed() {
+		t.Error("deployment_id should be Computed")
+	}
+	if deplIDAttr.IsRequired() || deplIDAttr.IsOptional() {
+		t.Error("deployment_id should not be Required or Optional")
+	}
 }


### PR DESCRIPTION
The `dagsterplus_deployment` resource and data source previously exposed only the deployment name as the Terraform `id`, which wasn't useful for callers needing the underlying numeric deployment ID (e.g. for `createOrUpdateAgentPermissions` GraphQL mutations). This change surfaces the deployment ID as a dedicated `deployment_id` attribute on both the resource and data source by reading the `deploymentId` field already available on the `deploymentByName` query response. The `id` attribute is updated to use the deployment ID as well, making imports and cross-resource references consistent with what the Dagster GraphQL API expects.

https://github.com/dagster-io/terraform-provider-dagsterplus/issues/12