### PR TITLE
Remove non-functional branch_deployments_grants from agent_token (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Thi
 
 ## [Unreleased]
 
+### Breaking Changes
+- `dagsterplus_agent_token`: removed the `branch_deployments_grants` attribute. Setting it always failed at apply with an `Internal Server Error` (`PythonError`) — the Dagster+ API does not support scoping an agent token to the branch deployments of a single parent deployment. Agent tokens support only three grant scopes: the organization (`organization`), specific full deployments (`deployment_grants`), and all branch deployments (`all_branch_deployments`). **Migration:** remove any `branch_deployments_grants = [...]` lines from your `dagsterplus_agent_token` blocks; to grant an agent across branch deployments, set `all_branch_deployments = true`. ([#42](https://github.com/dagster-io/terraform-provider-dagsterplus/issues/42))
+
 ### Added
 - `dagsterplus_alert_policy`: the `notification_service` block now supports a generic `webhook` notification type, mirroring the webhook channel available in the Dagster+ UI (e.g. for IncidentIO). Set `type = "webhook"` and configure `webhook_url` (the endpoint), `headers` (a `map(string)` of arbitrary request headers such as authentication tokens — marked sensitive), and `body_template` (a templated request body). This is distinct from the Teams-specific `microsoft_teams` type. Note that the webhook URL's domain must be allowlisted for your organization (a support-gated setting), and `body_template` tokens must be lowercase identifiers (e.g. `{{alert_summary}}`) or environment variables (e.g. `{{env.MY_SECRET}}`). Existing configs are unaffected; `webhook` is a new value added to the notification `type` enum. ([#40](https://github.com/dagster-io/terraform-provider-dagsterplus/issues/40))
 

--- a/docs/resources/agent_token.md
+++ b/docs/resources/agent_token.md
@@ -3,12 +3,12 @@
 page_title: "dagsterplus_agent_token Resource - dagsterplus"
 subcategory: ""
 description: |-
-  Manages a Dagster+ agent token and its permission grants. The token value is only available at creation time; it cannot be recovered after import. Changing the name forces a new resource. Agent tokens only ever carry the AGENT permission, so the grant attributes only control which scopes the token is granted on.
+  Manages a Dagster+ agent token and its permission grants. The token value is only available at creation time; it cannot be recovered after import. Changing the name forces a new resource. Agent tokens only ever carry the AGENT permission, so the grant attributes only control which scopes the token is granted on. Dagster+ supports three agent-token grant scopes: the organization, specific full deployments, and all branch deployments. Unlike user/team grants, agent tokens cannot be scoped to the branch deployments of a single parent deployment.
 ---
 
 # dagsterplus_agent_token (Resource)
 
-Manages a Dagster+ agent token and its permission grants. The token value is only available at creation time; it cannot be recovered after import. Changing the name forces a new resource. Agent tokens only ever carry the AGENT permission, so the grant attributes only control which scopes the token is granted on.
+Manages a Dagster+ agent token and its permission grants. The token value is only available at creation time; it cannot be recovered after import. Changing the name forces a new resource. Agent tokens only ever carry the AGENT permission, so the grant attributes only control which scopes the token is granted on. Dagster+ supports three agent-token grant scopes: the organization, specific full deployments, and all branch deployments. Unlike user/team grants, agent tokens cannot be scoped to the branch deployments of a single parent deployment.
 
 ## Example Usage
 
@@ -46,7 +46,6 @@ resource "dagsterplus_agent_token" "ecs_agent" {
 ### Optional
 
 - `all_branch_deployments` (Boolean) Whether the token holds the AGENT grant across all branch deployments. Defaults to false.
-- `branch_deployments_grants` (Set of String) Names of full (parent) deployments whose branch deployments the token is granted the AGENT permission on.
 - `deployment_grants` (Set of String) Names of full deployments the token is granted the AGENT permission on.
 - `organization` (Boolean) Whether the token holds the organization-scoped AGENT grant. Dagster+ creates this grant automatically with every new token; set to false to remove it. Defaults to true.
 

--- a/integration/main.tf
+++ b/integration/main.tf
@@ -188,11 +188,10 @@ resource "dagsterplus_service_user_branch_deployments_grant" "standalone" {
 # ---------------------------------------------------------------------------
 
 resource "dagsterplus_agent_token" "inline" {
-  name                      = "acc-tf-agent-inline"
-  organization              = false
-  all_branch_deployments    = true
-  deployment_grants         = [dagsterplus_deployment.test.name]
-  branch_deployments_grants = [dagsterplus_deployment.test.name]
+  name                   = "acc-tf-agent-inline"
+  organization           = false
+  all_branch_deployments = true
+  deployment_grants      = [dagsterplus_deployment.test.name]
 }
 
 resource "dagsterplus_agent_token" "standalone" {

--- a/internal/client/agent_token_grants.go
+++ b/internal/client/agent_token_grants.go
@@ -14,7 +14,7 @@ import (
 // grants) there is no grant level, custom role, or location grant to track here.
 type AgentTokenGrant struct {
 	AgentTokenID    string
-	DeploymentScope string // "organization" | "deployment" | "all_branch_deployments" | "branch_deployments"
+	DeploymentScope string // "organization" | "deployment" | "all_branch_deployments"
 	DeploymentID    int64  // 0 for organization / all_branch_deployments scopes
 }
 
@@ -40,12 +40,6 @@ func findAgentTokenGrantInFields(f schema.AgentTokenGrantsFields, agentTokenID, 
 			return nil
 		}
 		return agentTokenGrantFromFields(agentTokenID, g.DeploymentScope, g.DeploymentId)
-	case "branch_deployments":
-		for _, g := range f.PerBaseBranchDeploymentsPermissionGrants {
-			if int64(g.DeploymentId) == deploymentID {
-				return agentTokenGrantFromFields(agentTokenID, g.DeploymentScope, g.DeploymentId)
-			}
-		}
 	default:
 		for _, g := range f.DeploymentPermissionGrants {
 			if int64(g.DeploymentId) == deploymentID {
@@ -127,28 +121,6 @@ func (c *Client) ListAgentTokenDeploymentGrants(ctx context.Context, agentTokenI
 		return grants, nil
 	default:
 		return nil, fmt.Errorf("ListAgentTokenDeploymentGrants: agent token %q not found", agentTokenID)
-	}
-}
-
-// ListAgentTokenBranchDeploymentsGrants returns all per-base-branch grants for an agent token.
-func (c *Client) ListAgentTokenBranchDeploymentsGrants(ctx context.Context, agentTokenID string) ([]AgentTokenGrant, error) {
-	intID, err := strconv.Atoi(agentTokenID)
-	if err != nil {
-		return nil, fmt.Errorf("ListAgentTokenBranchDeploymentsGrants: invalid agent token id %q: %w", agentTokenID, err)
-	}
-	resp, err := schema.GetAgentTokenGrants(ctx, c.gqlClient(""), intID)
-	if err != nil {
-		return nil, fmt.Errorf("ListAgentTokenBranchDeploymentsGrants: %w", err)
-	}
-	switch r := resp.AgentTokenOrError.(type) {
-	case *schema.GetAgentTokenGrantsAgentTokenOrErrorDagsterCloudAgentToken:
-		var grants []AgentTokenGrant
-		for _, g := range r.Permissions.AgentTokenGrantsFields.PerBaseBranchDeploymentsPermissionGrants {
-			grants = append(grants, *agentTokenGrantFromFields(agentTokenID, g.DeploymentScope, g.DeploymentId))
-		}
-		return grants, nil
-	default:
-		return nil, fmt.Errorf("ListAgentTokenBranchDeploymentsGrants: agent token %q not found", agentTokenID)
 	}
 }
 

--- a/internal/client/agent_token_grants_test.go
+++ b/internal/client/agent_token_grants_test.go
@@ -12,7 +12,7 @@ import (
 
 // agentTokenPermissions builds a DagsterCloudScopedPermissionGrants payload.
 // Absent grants are represented with an empty grant string.
-func agentTokenPermissions(org, allBranch map[string]any, deployment, branch []any) map[string]any {
+func agentTokenPermissions(org, allBranch map[string]any, deployment []any) map[string]any {
 	if org == nil {
 		org = map[string]any{"grant": "", "deploymentScope": "ORGANIZATION", "deploymentId": 0}
 	}
@@ -20,10 +20,9 @@ func agentTokenPermissions(org, allBranch map[string]any, deployment, branch []a
 		allBranch = map[string]any{"grant": "", "deploymentScope": "ALL_BRANCH_DEPLOYMENTS", "deploymentId": 0}
 	}
 	return map[string]any{
-		"organizationPermissionGrant":              org,
-		"allBranchDeploymentsPermissionGrant":      allBranch,
-		"perBaseBranchDeploymentsPermissionGrants": branch,
-		"deploymentPermissionGrants":               deployment,
+		"organizationPermissionGrant":         org,
+		"allBranchDeploymentsPermissionGrant": allBranch,
+		"deploymentPermissionGrants":          deployment,
 	}
 }
 
@@ -39,7 +38,7 @@ func TestSetAgentTokenGrant_Success(t *testing.T) {
 				"id":         123,
 				"permissions": agentTokenPermissions(nil, nil, []any{
 					map[string]any{"grant": "AGENT", "deploymentScope": "DEPLOYMENT", "deploymentId": 42},
-				}, []any{}),
+				}),
 			},
 		})
 	}))
@@ -69,7 +68,7 @@ func TestSetAgentTokenGrant_Organization(t *testing.T) {
 				"id":         123,
 				"permissions": agentTokenPermissions(
 					map[string]any{"grant": "AGENT", "deploymentScope": "ORGANIZATION", "deploymentId": 0},
-					nil, []any{}, []any{}),
+					nil, []any{}),
 			},
 		})
 	}))
@@ -133,7 +132,7 @@ func TestGetAgentTokenGrant_Found(t *testing.T) {
 				"id":         99,
 				"permissions": agentTokenPermissions(nil, nil, []any{
 					map[string]any{"grant": "AGENT", "deploymentScope": "DEPLOYMENT", "deploymentId": 7},
-				}, []any{}),
+				}),
 			},
 		})
 	}))
@@ -157,7 +156,7 @@ func TestGetAgentTokenGrant_OrganizationAbsent(t *testing.T) {
 			"agentTokenOrError": map[string]any{
 				"__typename":  "DagsterCloudAgentToken",
 				"id":          99,
-				"permissions": agentTokenPermissions(nil, nil, []any{}, []any{}),
+				"permissions": agentTokenPermissions(nil, nil, []any{}),
 			},
 		})
 	}))
@@ -200,7 +199,7 @@ func TestListAgentTokenDeploymentGrants_Success(t *testing.T) {
 				"permissions": agentTokenPermissions(nil, nil, []any{
 					map[string]any{"grant": "AGENT", "deploymentScope": "DEPLOYMENT", "deploymentId": 1},
 					map[string]any{"grant": "AGENT", "deploymentScope": "DEPLOYMENT", "deploymentId": 2},
-				}, []any{}),
+				}),
 			},
 		})
 	}))
@@ -212,32 +211,6 @@ func TestListAgentTokenDeploymentGrants_Success(t *testing.T) {
 	}
 	if len(grants) != 2 {
 		t.Fatalf("len(grants) = %d, want 2", len(grants))
-	}
-}
-
-func TestListAgentTokenBranchDeploymentsGrants_Success(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gqlOK(w, map[string]any{
-			"agentTokenOrError": map[string]any{
-				"__typename": "DagsterCloudAgentToken",
-				"id":         99,
-				"permissions": agentTokenPermissions(nil, nil, []any{}, []any{
-					map[string]any{"grant": "AGENT", "deploymentScope": "ALL_BRANCH_DEPLOYMENTS", "deploymentId": 5},
-				}),
-			},
-		})
-	}))
-	defer srv.Close()
-
-	grants, err := newClient(srv).ListAgentTokenBranchDeploymentsGrants(context.Background(), "99")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(grants) != 1 {
-		t.Fatalf("len(grants) = %d, want 1", len(grants))
-	}
-	if grants[0].DeploymentScope != "branch_deployments" {
-		t.Errorf("DeploymentScope = %q, want branch_deployments", grants[0].DeploymentScope)
 	}
 }
 

--- a/internal/client/schema/generated.go
+++ b/internal/client/schema/generated.go
@@ -833,10 +833,9 @@ func (v *AgentTokenFields) GetRevoked() bool { return v.Revoked }
 // so the grant value is hardcoded in the mutations below and never surfaced to
 // the provider.
 type AgentTokenGrantsFields struct {
-	OrganizationPermissionGrant              AgentTokenGrantsFieldsOrganizationPermissionGrantDagsterCloudScopedPermissionGrant                `json:"organizationPermissionGrant"`
-	AllBranchDeploymentsPermissionGrant      AgentTokenGrantsFieldsAllBranchDeploymentsPermissionGrantDagsterCloudScopedPermissionGrant        `json:"allBranchDeploymentsPermissionGrant"`
-	PerBaseBranchDeploymentsPermissionGrants []AgentTokenGrantsFieldsPerBaseBranchDeploymentsPermissionGrantsDagsterCloudScopedPermissionGrant `json:"perBaseBranchDeploymentsPermissionGrants"`
-	DeploymentPermissionGrants               []AgentTokenGrantsFieldsDeploymentPermissionGrantsDagsterCloudScopedPermissionGrant               `json:"deploymentPermissionGrants"`
+	OrganizationPermissionGrant         AgentTokenGrantsFieldsOrganizationPermissionGrantDagsterCloudScopedPermissionGrant         `json:"organizationPermissionGrant"`
+	AllBranchDeploymentsPermissionGrant AgentTokenGrantsFieldsAllBranchDeploymentsPermissionGrantDagsterCloudScopedPermissionGrant `json:"allBranchDeploymentsPermissionGrant"`
+	DeploymentPermissionGrants          []AgentTokenGrantsFieldsDeploymentPermissionGrantsDagsterCloudScopedPermissionGrant        `json:"deploymentPermissionGrants"`
 }
 
 // GetOrganizationPermissionGrant returns AgentTokenGrantsFields.OrganizationPermissionGrant, and is useful for accessing the field via an interface.
@@ -847,11 +846,6 @@ func (v *AgentTokenGrantsFields) GetOrganizationPermissionGrant() AgentTokenGran
 // GetAllBranchDeploymentsPermissionGrant returns AgentTokenGrantsFields.AllBranchDeploymentsPermissionGrant, and is useful for accessing the field via an interface.
 func (v *AgentTokenGrantsFields) GetAllBranchDeploymentsPermissionGrant() AgentTokenGrantsFieldsAllBranchDeploymentsPermissionGrantDagsterCloudScopedPermissionGrant {
 	return v.AllBranchDeploymentsPermissionGrant
-}
-
-// GetPerBaseBranchDeploymentsPermissionGrants returns AgentTokenGrantsFields.PerBaseBranchDeploymentsPermissionGrants, and is useful for accessing the field via an interface.
-func (v *AgentTokenGrantsFields) GetPerBaseBranchDeploymentsPermissionGrants() []AgentTokenGrantsFieldsPerBaseBranchDeploymentsPermissionGrantsDagsterCloudScopedPermissionGrant {
-	return v.PerBaseBranchDeploymentsPermissionGrants
 }
 
 // GetDeploymentPermissionGrants returns AgentTokenGrantsFields.DeploymentPermissionGrants, and is useful for accessing the field via an interface.
@@ -931,31 +925,6 @@ func (v *AgentTokenGrantsFieldsOrganizationPermissionGrantDagsterCloudScopedPerm
 
 // GetDeploymentId returns AgentTokenGrantsFieldsOrganizationPermissionGrantDagsterCloudScopedPermissionGrant.DeploymentId, and is useful for accessing the field via an interface.
 func (v *AgentTokenGrantsFieldsOrganizationPermissionGrantDagsterCloudScopedPermissionGrant) GetDeploymentId() int {
-	return v.DeploymentId
-}
-
-// AgentTokenGrantsFieldsPerBaseBranchDeploymentsPermissionGrantsDagsterCloudScopedPermissionGrant includes the requested fields of the GraphQL type DagsterCloudScopedPermissionGrant.
-// The GraphQL type's documentation follows.
-//
-// If the deploymentId is null, then this represents an organization grant.
-type AgentTokenGrantsFieldsPerBaseBranchDeploymentsPermissionGrantsDagsterCloudScopedPermissionGrant struct {
-	Grant           PermissionGrant           `json:"grant"`
-	DeploymentScope PermissionDeploymentScope `json:"deploymentScope"`
-	DeploymentId    int                       `json:"deploymentId"`
-}
-
-// GetGrant returns AgentTokenGrantsFieldsPerBaseBranchDeploymentsPermissionGrantsDagsterCloudScopedPermissionGrant.Grant, and is useful for accessing the field via an interface.
-func (v *AgentTokenGrantsFieldsPerBaseBranchDeploymentsPermissionGrantsDagsterCloudScopedPermissionGrant) GetGrant() PermissionGrant {
-	return v.Grant
-}
-
-// GetDeploymentScope returns AgentTokenGrantsFieldsPerBaseBranchDeploymentsPermissionGrantsDagsterCloudScopedPermissionGrant.DeploymentScope, and is useful for accessing the field via an interface.
-func (v *AgentTokenGrantsFieldsPerBaseBranchDeploymentsPermissionGrantsDagsterCloudScopedPermissionGrant) GetDeploymentScope() PermissionDeploymentScope {
-	return v.DeploymentScope
-}
-
-// GetDeploymentId returns AgentTokenGrantsFieldsPerBaseBranchDeploymentsPermissionGrantsDagsterCloudScopedPermissionGrant.DeploymentId, and is useful for accessing the field via an interface.
-func (v *AgentTokenGrantsFieldsPerBaseBranchDeploymentsPermissionGrantsDagsterCloudScopedPermissionGrant) GetDeploymentId() int {
 	return v.DeploymentId
 }
 
@@ -8845,11 +8814,6 @@ func (v *GetAgentTokenGrantsAgentTokenOrErrorDagsterCloudAgentTokenPermissionsDa
 	return v.AgentTokenGrantsFields.AllBranchDeploymentsPermissionGrant
 }
 
-// GetPerBaseBranchDeploymentsPermissionGrants returns GetAgentTokenGrantsAgentTokenOrErrorDagsterCloudAgentTokenPermissionsDagsterCloudScopedPermissionGrants.PerBaseBranchDeploymentsPermissionGrants, and is useful for accessing the field via an interface.
-func (v *GetAgentTokenGrantsAgentTokenOrErrorDagsterCloudAgentTokenPermissionsDagsterCloudScopedPermissionGrants) GetPerBaseBranchDeploymentsPermissionGrants() []AgentTokenGrantsFieldsPerBaseBranchDeploymentsPermissionGrantsDagsterCloudScopedPermissionGrant {
-	return v.AgentTokenGrantsFields.PerBaseBranchDeploymentsPermissionGrants
-}
-
 // GetDeploymentPermissionGrants returns GetAgentTokenGrantsAgentTokenOrErrorDagsterCloudAgentTokenPermissionsDagsterCloudScopedPermissionGrants.DeploymentPermissionGrants, and is useful for accessing the field via an interface.
 func (v *GetAgentTokenGrantsAgentTokenOrErrorDagsterCloudAgentTokenPermissionsDagsterCloudScopedPermissionGrants) GetDeploymentPermissionGrants() []AgentTokenGrantsFieldsDeploymentPermissionGrantsDagsterCloudScopedPermissionGrant {
 	return v.AgentTokenGrantsFields.DeploymentPermissionGrants
@@ -8885,8 +8849,6 @@ type __premarshalGetAgentTokenGrantsAgentTokenOrErrorDagsterCloudAgentTokenPermi
 
 	AllBranchDeploymentsPermissionGrant AgentTokenGrantsFieldsAllBranchDeploymentsPermissionGrantDagsterCloudScopedPermissionGrant `json:"allBranchDeploymentsPermissionGrant"`
 
-	PerBaseBranchDeploymentsPermissionGrants []AgentTokenGrantsFieldsPerBaseBranchDeploymentsPermissionGrantsDagsterCloudScopedPermissionGrant `json:"perBaseBranchDeploymentsPermissionGrants"`
-
 	DeploymentPermissionGrants []AgentTokenGrantsFieldsDeploymentPermissionGrantsDagsterCloudScopedPermissionGrant `json:"deploymentPermissionGrants"`
 }
 
@@ -8903,7 +8865,6 @@ func (v *GetAgentTokenGrantsAgentTokenOrErrorDagsterCloudAgentTokenPermissionsDa
 
 	retval.OrganizationPermissionGrant = v.AgentTokenGrantsFields.OrganizationPermissionGrant
 	retval.AllBranchDeploymentsPermissionGrant = v.AgentTokenGrantsFields.AllBranchDeploymentsPermissionGrant
-	retval.PerBaseBranchDeploymentsPermissionGrants = v.AgentTokenGrantsFields.PerBaseBranchDeploymentsPermissionGrants
 	retval.DeploymentPermissionGrants = v.AgentTokenGrantsFields.DeploymentPermissionGrants
 	return &retval, nil
 }
@@ -14726,11 +14687,6 @@ func (v *SetAgentGrantCreateOrUpdateAgentPermissionsDagsterCloudAgentTokenPermis
 	return v.AgentTokenGrantsFields.AllBranchDeploymentsPermissionGrant
 }
 
-// GetPerBaseBranchDeploymentsPermissionGrants returns SetAgentGrantCreateOrUpdateAgentPermissionsDagsterCloudAgentTokenPermissionsDagsterCloudScopedPermissionGrants.PerBaseBranchDeploymentsPermissionGrants, and is useful for accessing the field via an interface.
-func (v *SetAgentGrantCreateOrUpdateAgentPermissionsDagsterCloudAgentTokenPermissionsDagsterCloudScopedPermissionGrants) GetPerBaseBranchDeploymentsPermissionGrants() []AgentTokenGrantsFieldsPerBaseBranchDeploymentsPermissionGrantsDagsterCloudScopedPermissionGrant {
-	return v.AgentTokenGrantsFields.PerBaseBranchDeploymentsPermissionGrants
-}
-
 // GetDeploymentPermissionGrants returns SetAgentGrantCreateOrUpdateAgentPermissionsDagsterCloudAgentTokenPermissionsDagsterCloudScopedPermissionGrants.DeploymentPermissionGrants, and is useful for accessing the field via an interface.
 func (v *SetAgentGrantCreateOrUpdateAgentPermissionsDagsterCloudAgentTokenPermissionsDagsterCloudScopedPermissionGrants) GetDeploymentPermissionGrants() []AgentTokenGrantsFieldsDeploymentPermissionGrantsDagsterCloudScopedPermissionGrant {
 	return v.AgentTokenGrantsFields.DeploymentPermissionGrants
@@ -14766,8 +14722,6 @@ type __premarshalSetAgentGrantCreateOrUpdateAgentPermissionsDagsterCloudAgentTok
 
 	AllBranchDeploymentsPermissionGrant AgentTokenGrantsFieldsAllBranchDeploymentsPermissionGrantDagsterCloudScopedPermissionGrant `json:"allBranchDeploymentsPermissionGrant"`
 
-	PerBaseBranchDeploymentsPermissionGrants []AgentTokenGrantsFieldsPerBaseBranchDeploymentsPermissionGrantsDagsterCloudScopedPermissionGrant `json:"perBaseBranchDeploymentsPermissionGrants"`
-
 	DeploymentPermissionGrants []AgentTokenGrantsFieldsDeploymentPermissionGrantsDagsterCloudScopedPermissionGrant `json:"deploymentPermissionGrants"`
 }
 
@@ -14784,7 +14738,6 @@ func (v *SetAgentGrantCreateOrUpdateAgentPermissionsDagsterCloudAgentTokenPermis
 
 	retval.OrganizationPermissionGrant = v.AgentTokenGrantsFields.OrganizationPermissionGrant
 	retval.AllBranchDeploymentsPermissionGrant = v.AgentTokenGrantsFields.AllBranchDeploymentsPermissionGrant
-	retval.PerBaseBranchDeploymentsPermissionGrants = v.AgentTokenGrantsFields.PerBaseBranchDeploymentsPermissionGrants
 	retval.DeploymentPermissionGrants = v.AgentTokenGrantsFields.DeploymentPermissionGrants
 	return &retval, nil
 }
@@ -21214,11 +21167,6 @@ fragment AgentTokenGrantsFields on DagsterCloudScopedPermissionGrants {
 		deploymentScope
 		deploymentId
 	}
-	perBaseBranchDeploymentsPermissionGrants {
-		grant
-		deploymentScope
-		deploymentId
-	}
 	deploymentPermissionGrants {
 		grant
 		deploymentScope
@@ -22684,11 +22632,6 @@ fragment AgentTokenGrantsFields on DagsterCloudScopedPermissionGrants {
 		deploymentId
 	}
 	allBranchDeploymentsPermissionGrant {
-		grant
-		deploymentScope
-		deploymentId
-	}
-	perBaseBranchDeploymentsPermissionGrants {
 		grant
 		deploymentScope
 		deploymentId

--- a/internal/client/schema/queries/agent_tokens.graphql
+++ b/internal/client/schema/queries/agent_tokens.graphql
@@ -45,11 +45,6 @@ fragment AgentTokenGrantsFields on DagsterCloudScopedPermissionGrants {
     deploymentScope
     deploymentId
   }
-  perBaseBranchDeploymentsPermissionGrants {
-    grant
-    deploymentScope
-    deploymentId
-  }
   deploymentPermissionGrants {
     grant
     deploymentScope

--- a/internal/provider/acceptance_resource_agent_token_test.go
+++ b/internal/provider/acceptance_resource_agent_token_test.go
@@ -120,7 +120,7 @@ func TestAccAgentTokenResource_grants(t *testing.T) {
 				ResourceName:            "dagsterplus_agent_token.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"token", "name", "deployment_grants", "branch_deployments_grants"},
+				ImportStateVerifyIgnore: []string{"token", "name", "deployment_grants"},
 			},
 		},
 	})

--- a/internal/resources/resource_agent_token.go
+++ b/internal/resources/resource_agent_token.go
@@ -36,13 +36,12 @@ type agentTokenResource struct {
 // only express which scopes/deployments the token is granted on — there is no
 // grant level, custom role, or location grant to configure.
 type agentTokenResourceModel struct {
-	ID                      types.String `tfsdk:"id"`
-	Name                    types.String `tfsdk:"name"`
-	Token                   types.String `tfsdk:"token"`
-	Organization            types.Bool   `tfsdk:"organization"`
-	AllBranchDeployments    types.Bool   `tfsdk:"all_branch_deployments"`
-	DeploymentGrants        types.Set    `tfsdk:"deployment_grants"`
-	BranchDeploymentsGrants types.Set    `tfsdk:"branch_deployments_grants"`
+	ID                   types.String `tfsdk:"id"`
+	Name                 types.String `tfsdk:"name"`
+	Token                types.String `tfsdk:"token"`
+	Organization         types.Bool   `tfsdk:"organization"`
+	AllBranchDeployments types.Bool   `tfsdk:"all_branch_deployments"`
+	DeploymentGrants     types.Set    `tfsdk:"deployment_grants"`
 }
 
 func (r *agentTokenResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -54,7 +53,10 @@ func (r *agentTokenResource) Schema(_ context.Context, _ resource.SchemaRequest,
 		Description: "Manages a Dagster+ agent token and its permission grants. " +
 			"The token value is only available at creation time; it cannot be recovered after import. " +
 			"Changing the name forces a new resource. Agent tokens only ever carry the AGENT permission, " +
-			"so the grant attributes only control which scopes the token is granted on.",
+			"so the grant attributes only control which scopes the token is granted on. " +
+			"Dagster+ supports three agent-token grant scopes: the organization, specific full deployments, " +
+			"and all branch deployments. Unlike user/team grants, agent tokens cannot be scoped to the branch " +
+			"deployments of a single parent deployment.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "The token ID assigned by Dagster+.",
@@ -94,11 +96,6 @@ func (r *agentTokenResource) Schema(_ context.Context, _ resource.SchemaRequest,
 			},
 			"deployment_grants": schema.SetAttribute{
 				Description: "Names of full deployments the token is granted the AGENT permission on.",
-				Optional:    true,
-				ElementType: types.StringType,
-			},
-			"branch_deployments_grants": schema.SetAttribute{
-				Description: "Names of full (parent) deployments whose branch deployments the token is granted the AGENT permission on.",
 				Optional:    true,
 				ElementType: types.StringType,
 			},
@@ -161,27 +158,6 @@ func (r *agentTokenResource) applyGrants(ctx context.Context, tokenID string, pl
 			DeploymentID:    intID,
 		}); err != nil {
 			diags.AddError("Error setting deployment grant", err.Error())
-			return
-		}
-	}
-
-	var branchNames []string
-	diags.Append(plan.BranchDeploymentsGrants.ElementsAs(ctx, &branchNames, false)...)
-	if diags.HasError() {
-		return
-	}
-	for _, name := range branchNames {
-		intID, err := r.client.GetDeploymentIntID(ctx, name)
-		if err != nil {
-			diags.AddError("Error resolving parent deployment", err.Error())
-			return
-		}
-		if _, err := r.client.SetAgentTokenGrant(ctx, client.AgentTokenGrant{
-			AgentTokenID:    tokenID,
-			DeploymentScope: "branch_deployments",
-			DeploymentID:    intID,
-		}); err != nil {
-			diags.AddError("Error setting branch deployments grant", err.Error())
 			return
 		}
 	}
@@ -250,7 +226,6 @@ func (r *agentTokenResource) Read(ctx context.Context, req resource.ReadRequest,
 	state.AllBranchDeployments = types.BoolValue(allBranchErr == nil)
 
 	state.DeploymentGrants = r.refreshDeploymentNames(ctx, tok.ID, state.DeploymentGrants, "deployment", &resp.Diagnostics)
-	state.BranchDeploymentsGrants = r.refreshDeploymentNames(ctx, tok.ID, state.BranchDeploymentsGrants, "branch_deployments", &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -314,9 +289,8 @@ func (r *agentTokenResource) Update(ctx context.Context, req resource.UpdateRequ
 		}
 	}
 
-	// Remove deployment / branch grants no longer in plan.
+	// Remove deployment grants no longer in plan.
 	r.deleteRemovedDeploymentGrants(ctx, tokenID, plan.DeploymentGrants, state.DeploymentGrants, "deployment", &resp.Diagnostics)
-	r.deleteRemovedDeploymentGrants(ctx, tokenID, plan.BranchDeploymentsGrants, state.BranchDeploymentsGrants, "branch_deployments", &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -374,13 +348,12 @@ func (r *agentTokenResource) Delete(ctx context.Context, req resource.DeleteRequ
 func (r *agentTokenResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	// Token value is irrecoverable after creation.
 	state := agentTokenResourceModel{
-		ID:                      types.StringValue(req.ID),
-		Name:                    types.StringValue(""),
-		Token:                   types.StringValue(""),
-		Organization:            types.BoolValue(true),
-		AllBranchDeployments:    types.BoolValue(false),
-		DeploymentGrants:        types.SetNull(types.StringType),
-		BranchDeploymentsGrants: types.SetNull(types.StringType),
+		ID:                   types.StringValue(req.ID),
+		Name:                 types.StringValue(""),
+		Token:                types.StringValue(""),
+		Organization:         types.BoolValue(true),
+		AllBranchDeployments: types.BoolValue(false),
+		DeploymentGrants:     types.SetNull(types.StringType),
 	}
 
 	if tok, err := r.client.GetAgentToken(ctx, req.ID); err == nil {


### PR DESCRIPTION
## Summary

Fixes #42. Setting `branch_deployments_grants` on `dagsterplus_agent_token` always failed at apply:

```
│ Error: Error setting branch deployments grant
│ SetAgentTokenGrant: unexpected result type *schema.SetAgentGrantCreateOrUpdateAgentPermissionsPythonError
```

I reproduced the root cause directly against the live Dagster+ API. The `createOrUpdateAgentPermissions` mutation returns a 500 / `PythonError` when `deploymentScope: ALL_BRANCH_DEPLOYMENTS` is combined with a non-zero `deploymentId` for an agent token:

| Scope sent | Request | Result |
|---|---|---|
| `branch_deployments_grants` (per-parent) | `ALL_BRANCH_DEPLOYMENTS` + `deploymentId` + `grant: AGENT` | ❌ `PythonError` — Internal Server Error |
| `all_branch_deployments` | `ALL_BRANCH_DEPLOYMENTS`, no `deploymentId` | ✅ works |
| `deployment` (specific) | `DEPLOYMENT` + `deploymentId` | ✅ works |

Unlike user/team/service-user grants, **agent tokens cannot be scoped to the branch deployments of a single parent deployment**. They support only three grant scopes: the organization, specific full deployments, and all branch deployments. The attribute could never succeed, so this PR removes it rather than leaving a broken knob.

## Changes

- Remove the `branch_deployments_grants` attribute + all Create/Read/Update/Import handling from `dagsterplus_agent_token`; clarify the resource description with the supported scopes and limitation.
- Remove the `branch_deployments` case in `findAgentTokenGrantInFields` and the unused `ListAgentTokenBranchDeploymentsGrants` client method.
- Drop `perBaseBranchDeploymentsPermissionGrants` from the agent-token GraphQL fragment and regenerate `generated.go` (user/team/service-user fragments keep it — they legitimately support per-base-branch grants).
- Update tests, `integration/main.tf`, regenerate `docs/resources/agent_token.md`, and add a `### Breaking Changes` CHANGELOG entry with migration guidance.

## Breaking change

Removing a schema attribute is breaking for anyone with it in config. In practice the attribute never worked (apply always 500'd), so no working config depends on it.

**Migration:** remove `branch_deployments_grants = [...]` lines from `dagsterplus_agent_token` blocks; use `all_branch_deployments = true` to grant an agent across branch deployments.

## Testing

- `go build`, `go vet`, `gofmt -l` (clean)
- Unit tests: `internal/client`, `internal/resources`, `internal/datasources` pass
- `go mod tidy` clean; `make generate` clean
- `make dev-plan` against the real API: plans cleanly (36 to add, 0 change, 0 destroy); the agent token now plans without the attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)