### PR TITLE
Persist agent token state before applying grants (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Thi
 
 ## [Unreleased]
 
+### Fixed
+- `dagsterplus_agent_token`: a grant failure during `Create` no longer leaks an untracked token. The token was created in Dagster+ before its grants were applied, but Terraform state was only written after all grants succeeded — so any grant failure (a transient API error, an unauthorized token, a deleted deployment referenced in `deployment_grants`) left a real token with no state entry, and the next `apply` created another token. Create now persists state as soon as the token exists remotely, before applying grants, so a subsequent apply reconciles the existing token instead of leaking a new one. ([#44](https://github.com/dagster-io/terraform-provider-dagsterplus/issues/44))
+
 ### Added
 - `dagsterplus_alert_policy`: the `notification_service` block now supports a generic `webhook` notification type, mirroring the webhook channel available in the Dagster+ UI (e.g. for IncidentIO). Set `type = "webhook"` and configure `webhook_url` (the endpoint), `headers` (a `map(string)` of arbitrary request headers such as authentication tokens — marked sensitive), and `body_template` (a templated request body). This is distinct from the Teams-specific `microsoft_teams` type. Note that the webhook URL's domain must be allowlisted for your organization (a support-gated setting), and `body_template` tokens must be lowercase identifiers (e.g. `{{alert_summary}}`) or environment variables (e.g. `{{env.MY_SECRET}}`). Existing configs are unaffected; `webhook` is a new value added to the notification `type` enum. ([#40](https://github.com/dagster-io/terraform-provider-dagsterplus/issues/40))
 

--- a/internal/provider/acceptance_resource_agent_token_test.go
+++ b/internal/provider/acceptance_resource_agent_token_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/dagster-io/terraform-provider-dagsterplus/internal/client"
@@ -135,6 +136,71 @@ resource "dagsterplus_agent_token" "test" {
   deployment_grants      = %s
 }
 `, name, organization, allBranch, deploymentGrants)
+}
+
+// TestAccAgentTokenResource_partialCreateNoLeak reproduces issue #44: the token
+// is created in Dagster+ before its grants are applied, so a grant failure during
+// Create leaves a real token behind. Here the failure is induced deterministically
+// by pointing deployment_grants at a deployment that does not exist, which errors
+// in applyGrants after the token already exists remotely.
+//
+// The fix persists the token to Terraform state before applying grants, so the
+// failed create is tracked; the corrected re-apply reconciles that same token
+// rather than creating a new one. The token-count check is the discriminator:
+// with the bug, state was never written, so the re-apply would create a SECOND
+// token with the same name (count 2). With the fix, exactly one token exists.
+func TestAccAgentTokenResource_partialCreateNoLeak(t *testing.T) {
+	rName := "acc-tf-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+	missingDeployment := "acc-tf-nonexistent-" + acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckAgentTokenDestroyed(rName),
+		Steps: []resource.TestStep{
+			// Create fails while resolving the (nonexistent) deployment grant,
+			// after the token has already been created remotely.
+			{
+				Config:      providerConfig() + testAccAgentTokenGrantsConfig(rName, "true", "false", fmt.Sprintf("[%q]", missingDeployment)),
+				ExpectError: regexp.MustCompile("Error resolving deployment"),
+			},
+			// Re-apply with a valid config converges on a single token; no orphan
+			// was leaked by the failed create.
+			{
+				Config: providerConfig() + testAccAgentTokenConfig(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("dagsterplus_agent_token.test", "id"),
+					testAccCheckAgentTokenCount(rName, 1),
+				),
+			},
+		},
+	})
+}
+
+// testAccCheckAgentTokenCount asserts exactly `want` non-revoked tokens carry the
+// given name. Used to prove a failed create did not leak an untracked token.
+func testAccCheckAgentTokenCount(name string, want int) resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		c := client.New(
+			os.Getenv("DAGSTER_CLOUD_ORGANIZATION"),
+			os.Getenv("DAGSTER_CLOUD_API_TOKEN"),
+			"",
+		)
+		tokens, err := c.ListAgentTokens(context.Background())
+		if err != nil {
+			return fmt.Errorf("listing agent tokens: %w", err)
+		}
+		count := 0
+		for _, tok := range tokens {
+			if tok.Name == name {
+				count++
+			}
+		}
+		if count != want {
+			return fmt.Errorf("found %d agent tokens named %q, want %d (a leaked token indicates a partial-create failure was not tracked in state)", count, name, want)
+		}
+		return nil
+	}
 }
 
 func testAccCheckAgentTokenDestroyed(name string) resource.TestCheckFunc {

--- a/internal/resources/resource_agent_token.go
+++ b/internal/resources/resource_agent_token.go
@@ -204,6 +204,15 @@ func (r *agentTokenResource) Create(ctx context.Context, req resource.CreateRequ
 	plan.Name = types.StringValue(tok.Name)
 	plan.Token = types.StringValue(tok.Token)
 
+	// Persist state as soon as the token exists remotely, before applying any
+	// grants. If a grant step below fails, Terraform still records the token so
+	// a subsequent apply reconciles the existing token instead of leaking a new
+	// one (see issue #44).
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// Dagster+ auto-creates an organization-scoped AGENT grant with every new
 	// token. If the user opted out, remove it before applying the rest.
 	if !plan.Organization.ValueBool() {

--- a/internal/resources/resource_agent_token_test.go
+++ b/internal/resources/resource_agent_token_test.go
@@ -2,10 +2,17 @@ package resources
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/dagster-io/terraform-provider-dagsterplus/internal/client"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	rsschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 func TestAgentTokenResource_Schema(t *testing.T) {
@@ -62,5 +69,80 @@ func TestAgentTokenResource_Schema(t *testing.T) {
 	}
 	if tokenAttr.IsRequired() {
 		t.Error("token should not be Required")
+	}
+}
+
+// TestAgentTokenResource_Create_GrantFailurePersistsToken covers the partial-create
+// path described in issue #44: when the token is created remotely but a subsequent
+// grant call fails, Create must still record the token in Terraform state so a later
+// apply reconciles the existing token instead of leaking a new one.
+func TestAgentTokenResource_Create_GrantFailurePersistsToken(t *testing.T) {
+	ctx := context.Background()
+
+	// Server: CreateAgentToken succeeds; the grant mutation fails with a
+	// PythonError so applyGrants returns an error mid-Create.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Query string `json:"query"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(body.Query, "CreateAgentToken"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{
+				"createAgentToken": map[string]any{
+					"__typename":  "DagsterCloudAgentToken",
+					"id":          123,
+					"description": "acc-tf-issue44",
+					"token":       "secret-value",
+				},
+			}})
+		case strings.Contains(body.Query, "SetAgentGrant"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{
+				"createOrUpdateAgentPermissions": map[string]any{
+					"__typename": "PythonError",
+				},
+			}})
+		default:
+			t.Errorf("unexpected query: %s", body.Query)
+		}
+	}))
+	defer srv.Close()
+
+	r := NewAgentTokenResource().(*agentTokenResource)
+	r.client = client.New("acc-org", "acc-token", srv.URL)
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	sch := schemaResp.Schema
+
+	planRaw := tftypes.NewValue(sch.Type().TerraformType(ctx), map[string]tftypes.Value{
+		"id":                        tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+		"name":                      tftypes.NewValue(tftypes.String, "acc-tf-issue44"),
+		"token":                     tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+		"organization":              tftypes.NewValue(tftypes.Bool, true),
+		"all_branch_deployments":    tftypes.NewValue(tftypes.Bool, false),
+		"deployment_grants":         tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, nil),
+		"branch_deployments_grants": tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, nil),
+	})
+
+	req := resource.CreateRequest{Plan: tfsdk.Plan{Schema: sch, Raw: planRaw}}
+	resp := &resource.CreateResponse{State: tfsdk.State{Schema: sch}}
+	r.Create(ctx, req, resp)
+
+	// The grant failure must surface as an error...
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected Create to report an error when the grant call fails")
+	}
+
+	// ...but the token must still be recorded in state so it is not leaked.
+	var state agentTokenResourceModel
+	resp.Diagnostics.Append(resp.State.Get(ctx, &state)...)
+	if state.ID.ValueString() != "123" {
+		t.Errorf("state ID = %q, want 123 (token must be persisted despite grant failure)", state.ID.ValueString())
+	}
+	if state.Token.ValueString() != "secret-value" {
+		t.Errorf("state Token = %q, want secret-value", state.Token.ValueString())
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #44. `dagsterplus_agent_token`'s `Create` created the token in Dagster+ **before** applying grants, but only wrote Terraform state **after** all grants succeeded. If any grant step failed, `Create` returned an error without ever calling `resp.State.Set` — so the token existed in Dagster+ with no state entry, and the next `apply` created *another* token, leaking one orphaned token per failed attempt.

Failure modes that trigger this: a transient API error, an unauthorized token, or a deleted deployment referenced in `deployment_grants`.

## Change

`Create` now persists state as soon as the token exists remotely (right after `CreateAgentToken`), before the org-grant delete and `applyGrants`. State is still re-set at the end for the success path. A failed create is therefore tracked, and a corrected re-apply reconciles the existing token instead of leaking a new one.

## Tests

- **Unit** (`internal/resources/resource_agent_token_test.go`): `TestAgentTokenResource_Create_GrantFailurePersistsToken` drives `Create` against an `httptest` GraphQL server where `CreateAgentToken` succeeds but the grant mutation returns a `PythonError`; asserts `Create` reports an error **and** the token id/value are persisted to state. Verified it fails without the fix (`state ID = "", want 123`).
- **Acceptance** (`internal/provider/acceptance_resource_agent_token_test.go`): `TestAccAgentTokenResource_partialCreateNoLeak` fails a create by pointing `deployment_grants` at a nonexistent deployment, re-applies with a valid config, and asserts **exactly one** token with the name exists (no orphan leaked). Verified passing against the live API.

## Not a breaking change

No schema changes — no attribute removed/renamed/retyped, no `Required`/`RequiresReplace`/`OneOf`/default/import-ID changes. The `.tf` interface is unchanged and the success path is identical; the only behavioral difference is on the failure path (token now tracked instead of leaked). Logged under `### Fixed`.

## Checks

- `go build ./...`, `go vet ./...`, `gofmt -l .` (clean)
- Unit tests: `internal/client`, `internal/resources`, `internal/datasources` pass
- `go mod tidy` clean
- Acceptance test passes against the live API

## Relationship to #43

Independent of #43 (removes the non-functional `branch_deployments_grants`). #43 fixes one specific always-failing grant path; this fixes the underlying partial-create leak for *any* grant failure. Different functions in the same file (#43 in `applyGrants`, this in `Create`), so they merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)